### PR TITLE
Add skyfield and shapely; rubin_sim 0.11.1

### DIFF
--- a/rubin-sim/conda/meta.yaml
+++ b/rubin-sim/conda/meta.yaml
@@ -50,6 +50,8 @@ test:
     - scipy
     - sqlalchemy
     - sqlite
+    - shapely
+    - skyfield
   source_files:
     - rubin_sim
     - tests
@@ -84,3 +86,6 @@ requirements:
     - scipy
     - sqlalchemy
     - sqlite
+    - shapely
+    - skyfield
+    


### PR DESCRIPTION
This lets the recipe run with rubin_sim 0.11.1 (which add satellite dodging options for the scheduler and require shapely and skyfield packages).

I am noticing that there are many packages not included in your recipe which are requirements for us; mostly I understand this, as you're using a limited set of the rubin_sim capabilities.  
One requirement that I don't see here but I think might have been useful is 'requests' -- isn't this necessary for downloading the rubin_sim data, using rs_download_data? or are you downloading the data using a different option? 