### PR TITLE
Add tqdm to requirements for rubin_sim

### DIFF
--- a/rubin-sim/conda/meta.yaml
+++ b/rubin-sim/conda/meta.yaml
@@ -52,6 +52,7 @@ test:
     - sqlite
     - shapely
     - skyfield
+    - tqdm
   source_files:
     - rubin_sim
     - tests
@@ -88,4 +89,5 @@ requirements:
     - sqlite
     - shapely
     - skyfield
+    - tqdm
     


### PR DESCRIPTION
There is a PR approved on rubin_sim which adds tqdm to the requirements. 
Looks like tqdm is low overhead and doesn't add significant requirements -- but what it does is add a visual meter to how far you are through a loop, if the loop is passed through tqdm.  https://tqdm.github.io
A contributor wanted it to see how far they were in calculating a metric, when they were doing that work interactively, and it seemed worthwhile. 