### PR TITLE
Remove setuptools from requirements

### DIFF
--- a/rubin-sim/conda/meta.yaml
+++ b/rubin-sim/conda/meta.yaml
@@ -50,14 +50,12 @@ requirements:
     - python {{ python }}
     - pip
     - setuptools_scm_git_archive
-    - setuptools =62
-    - setuptools_scm =6.4
+    - setuptools_scm
   build:
     - python {{ python }}
     - pip
     - setuptools_scm_git_archive
-    - setuptools =62
-    - setuptools_scm =6.4
+    - setuptools_scm
     - numpy {{ numpy }}
   run:
     - python {{ python }}


### PR DESCRIPTION
I admit I do not know where to look to see this actually tested in the lsst-ts pipeline, but I think this does the job. 
https://tssw-ci.lsst.org/job/ts-conda-build-linux-aarch64/job/u%252Flynnej%252Ffix_rubin_sim_build/ 